### PR TITLE
Add uplaod for File type

### DIFF
--- a/src/main/java/com/cloudconvert/dto/response/TaskResponse.java
+++ b/src/main/java/com/cloudconvert/dto/response/TaskResponse.java
@@ -143,26 +143,7 @@ public class TaskResponse extends Response {
 
             private String url;
 
-            private Parameters parameters;
-
-
-            @Getter
-            @Setter
-            @Accessors(chain = true)
-            @ToString
-            @EqualsAndHashCode
-            public static class Parameters {
-
-                private String expires;
-
-                private String maxFileCount;
-
-                private String maxFileSize;
-
-                private String redirect;
-
-                private String signature;
-            }
+            private Map<String, String> parameters;
         }
     }
 

--- a/src/main/java/com/cloudconvert/resource/async/AsyncImportFilesResource.java
+++ b/src/main/java/com/cloudconvert/resource/async/AsyncImportFilesResource.java
@@ -19,6 +19,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -66,6 +67,48 @@ public class AsyncImportFilesResource extends AbstractImportFilesResource<AsyncR
 
     @Override
     public AsyncResult<TaskResponseData> upload(
+        @NotNull final UploadImportRequest uploadImportRequest, @NotNull final File file
+    ) throws IOException, URISyntaxException {
+        return upload(upload(uploadImportRequest), file);
+    }
+
+    @Override
+    public AsyncResult<TaskResponseData> upload(
+        @NotNull final AsyncResult<TaskResponseData> taskResponseDataAsyncResult, @NotNull final File file
+    ) throws IOException, URISyntaxException {
+        try {
+            final Result<TaskResponseData> taskResponseDataResult = taskResponseDataAsyncResult.get();
+
+            if (HttpStatus.SC_CREATED == taskResponseDataResult.getStatus()) {
+                final TaskResponse taskResponse = taskResponseDataResult.getBody().get().getData();
+
+                return upload(taskResponse.getId(), taskResponse.getResult().getForm(), file);
+            } else {
+                return CompletedAsyncResult.<TaskResponseData>builder().result(Result.<TaskResponseData>builder()
+                    .status(taskResponseDataResult.getStatus()).message(taskResponseDataResult.getMessage()).build()).build();
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public AsyncResult<TaskResponseData> upload(
+        @NotNull final String taskId, @NotNull final TaskResponse.Result.Form taskResponseResultForm, @NotNull final File file
+    ) throws IOException, URISyntaxException {
+        try {
+            final URI multipartUri = new URI(taskResponseResultForm.getUrl());
+            final HttpEntity multipartHttpEntity = getMultipartHttpEntity(taskResponseResultForm, file);
+            final HttpUriRequest multipartHttpUriRequest = getHttpUriRequest(HttpPost.class, multipartUri, multipartHttpEntity);
+
+            return uploadPostProcess(taskId, asyncRequestExecutor.execute(multipartHttpUriRequest, VOID_TYPE_REFERENCE));
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public AsyncResult<TaskResponseData> upload(
         @NotNull final UploadImportRequest uploadImportRequest, @NotNull final InputStream inputStream
     ) throws IOException, URISyntaxException {
         return upload(upload(uploadImportRequest), inputStream);
@@ -97,33 +140,38 @@ public class AsyncImportFilesResource extends AbstractImportFilesResource<AsyncR
     ) throws IOException, URISyntaxException {
         try {
             final URI multipartUri = new URI(taskResponseResultForm.getUrl());
-            final HttpEntity multipartHttpEntity = getMultipartHttpEntity(taskResponseResultForm.getParameters(), inputStream);
+            final HttpEntity multipartHttpEntity = getMultipartHttpEntity(taskResponseResultForm, inputStream);
             final HttpUriRequest multipartHttpUriRequest = getHttpUriRequest(HttpPost.class, multipartUri, multipartHttpEntity);
 
-            final AsyncResult<Void> multipartVoidAsyncResult = asyncRequestExecutor.execute(multipartHttpUriRequest, VOID_TYPE_REFERENCE);
-            final Result<Void> multipartVoidResult = multipartVoidAsyncResult.get();
-
-            if (HttpStatus.SC_CREATED == multipartVoidResult.getStatus()) {
-                return asyncTasksResource.show(taskId);
-            } else if (HttpStatus.SC_SEE_OTHER == multipartVoidResult.getStatus()) {
-                final URI redirectUri = new URI(multipartVoidResult.getHeaders().get("Location"));
-                final HttpUriRequest redirectHttpUriRequest = getHttpUriRequest(HttpGet.class, redirectUri);
-
-                final AsyncResult<Void> redirectVoidAsyncResult = asyncRequestExecutor.execute(redirectHttpUriRequest, VOID_TYPE_REFERENCE);
-                final Result<Void> redirectVoidResult = redirectVoidAsyncResult.get();
-
-                if (HttpStatus.SC_CREATED == redirectVoidResult.getStatus()) {
-                    return asyncTasksResource.show(taskId);
-                } else {
-                    return CompletedAsyncResult.<TaskResponseData>builder().result(Result.<TaskResponseData>builder()
-                        .status(redirectVoidResult.getStatus()).message(redirectVoidResult.getMessage()).build()).build();
-                }
-            } else {
-                return CompletedAsyncResult.<TaskResponseData>builder().result(Result.<TaskResponseData>builder()
-                    .status(multipartVoidResult.getStatus()).message(multipartVoidResult.getMessage()).build()).build();
-            }
+            return uploadPostProcess(taskId, asyncRequestExecutor.execute(multipartHttpUriRequest, VOID_TYPE_REFERENCE));
         } catch (InterruptedException | ExecutionException e) {
             throw new IOException(e);
+        }
+    }
+
+    private AsyncResult<TaskResponseData> uploadPostProcess(
+        final String taskId, final AsyncResult<Void> multipartVoidAsyncResult
+    ) throws IOException, URISyntaxException, InterruptedException, ExecutionException {
+        final Result<Void> multipartVoidResult = multipartVoidAsyncResult.get();
+
+        if (HttpStatus.SC_CREATED == multipartVoidResult.getStatus()) {
+            return asyncTasksResource.show(taskId);
+        } else if (HttpStatus.SC_SEE_OTHER == multipartVoidResult.getStatus()) {
+            final URI redirectUri = new URI(multipartVoidResult.getHeaders().get("Location"));
+            final HttpUriRequest redirectHttpUriRequest = getHttpUriRequest(HttpGet.class, redirectUri);
+
+            final AsyncResult<Void> redirectVoidAsyncResult = asyncRequestExecutor.execute(redirectHttpUriRequest, VOID_TYPE_REFERENCE);
+            final Result<Void> redirectVoidResult = redirectVoidAsyncResult.get();
+
+            if (HttpStatus.SC_CREATED == redirectVoidResult.getStatus()) {
+                return asyncTasksResource.show(taskId);
+            } else {
+                return CompletedAsyncResult.<TaskResponseData>builder().result(Result.<TaskResponseData>builder()
+                    .status(redirectVoidResult.getStatus()).message(redirectVoidResult.getMessage()).build()).build();
+            }
+        } else {
+            return CompletedAsyncResult.<TaskResponseData>builder().result(Result.<TaskResponseData>builder()
+                .status(multipartVoidResult.getStatus()).message(multipartVoidResult.getMessage()).build()).build();
         }
     }
 

--- a/src/test/java/com/cloudconvert/client/AsyncCloudConvertClientTest.java
+++ b/src/test/java/com/cloudconvert/client/AsyncCloudConvertClientTest.java
@@ -697,8 +697,8 @@ public class AsyncCloudConvertClientTest extends AbstractTest {
     @Test
     public void import_upload_immediateUpload() throws Exception {
         final UploadImportRequest expectedUploadImportRequest = new UploadImportRequest().setRedirect("import-upload-redirect");
-        final TaskResponse.Result.Form.Parameters parameters = new TaskResponse.Result.Form.Parameters().setExpires("expires")
-            .setMaxFileCount("max-file-count").setMaxFileSize("max-file-size").setRedirect("redirect").setSignature("signature");
+        final Map<String, String> parameters = ImmutableMap.of("expires", "expires", "max-file-count", "max-file-count",
+            "max-file-size", "max-file-size", "redirect", "redirect", "signature", "signature");
         final TaskResponse taskResponse = new TaskResponse().setId("import-upload-task-id").setResult(
             new TaskResponse.Result().setForm(new TaskResponse.Result.Form().setUrl("import-upload-task-result-form-url").setParameters(parameters)));
         final TaskResponseData taskResponseData = new TaskResponseData().setData(taskResponse);

--- a/src/test/java/com/cloudconvert/client/CloudConvertClientTest.java
+++ b/src/test/java/com/cloudconvert/client/CloudConvertClientTest.java
@@ -694,8 +694,8 @@ public class CloudConvertClientTest extends AbstractTest {
     @Test
     public void import_upload_immediateUpload() throws Exception {
         final UploadImportRequest expectedUploadImportRequest = new UploadImportRequest().setRedirect("import-upload-redirect");
-        final TaskResponse.Result.Form.Parameters parameters = new TaskResponse.Result.Form.Parameters().setExpires("expires")
-            .setMaxFileCount("max-file-count").setMaxFileSize("max-file-size").setRedirect("redirect").setSignature("signature");
+        final Map<String, String> parameters = ImmutableMap.of("expires", "expires", "max-file-count", "max-file-count",
+            "max-file-size", "max-file-size", "redirect", "redirect", "signature", "signature");
         final TaskResponse taskResponse = new TaskResponse().setId("import-upload-task-id").setResult(
             new TaskResponse.Result().setForm(new TaskResponse.Result.Form().setUrl("import-upload-task-result-form-url").setParameters(parameters)));
         final TaskResponseData taskResponseData = new TaskResponseData().setData(taskResponse);


### PR DESCRIPTION
Changes:
- Add possibility to upload file in addition to InputStream;
- Fix filename when uploading as InputStream;
- Change form parameter to map and add those dynamically;

Under the hood File is converted to InputStream anyway, as it is a requirement for async client. If we try to upload File object with async client, it fails with ContentTooLongException, as it expects multipart data too be buffered